### PR TITLE
Update main.py eval_only function

### DIFF
--- a/main.py
+++ b/main.py
@@ -409,8 +409,6 @@ def eval_only(model, device):
         )
         print('Evaluation finished. mAPs: ' + str(ap50_per_class) + '. Evaluation loss: ' + str(epoch_loss_val))
     else:
-        print("CSV ARGS NOT WORKING !!!!")
-        exit()
         ap50_per_class, epoch_loss_val, coco_data = evaluate(
             model=model,
             criterion=criterion,


### PR DESCRIPTION
There was an exit() command and a print statement on line 411 and 412 which were used for debugging earlier of the evalute_csv function. Removed now as they are not needed any more. --Kaustubh