### PR TITLE
Update evaluation.sh to set --csv flag default value

### DIFF
--- a/configs/def-detr-base/mammo/evaluation.sh
+++ b/configs/def-detr-base/mammo/evaluation.sh
@@ -14,4 +14,4 @@ CUDA_VISIBLE_DEVICES=0 python -u main.py \
 --mode eval \
 --output_dir ${OUTPUT_DIR} \
 --resume /Path/to/best teacher wts \
---csv True
+--csv False


### PR DESCRIPTION
Updating the mammo/evaluation.sh by setting the default value of --csv as False so that the script does'nt assume the target dataset to be of classification unless specified by the user. --Kaustubh.